### PR TITLE
display IPv6 addresses correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_CHECK_LIB([seccomp], [seccomp_init])
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h stdio.h unistd.h stdint.h string.h time.h signal.h])
 AC_CHECK_HEADERS([syslog.h fcntl.h seccomp.h netdb.h net/if.h netinet/in.h])
-AC_CHECK_HEADERS([sys/types.h sys/stat.h sys/ioctl.h sys/select.h sys/socket.h])
+AC_CHECK_HEADERS([sys/types.h sys/stat.h sys/ioctl.h sys/epoll.h sys/socket.h])
 AC_CHECK_HEADERS([grp.h pwd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -75,7 +75,7 @@ AC_TYPE_UINT64_T
 
 # Checks for library functions.
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([memset select socket])
+AC_CHECK_FUNCS([memset socket])
 
 # Sanity check for configure
 AC_CONFIG_SRCDIR([src/meshvpn.c])

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -120,6 +120,15 @@ int cryptoCalculateSHA512(unsigned char *hash_buf, const int hash_len, const uns
 int cryptoSetSessionKeysFromPassword(struct s_crypto *session_ctx, const unsigned char *password, const int password_len, const int cipher_algorithm, const int hmac_algorithm);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+#include <openssl/engine.h>
+
+struct ossl_init_settings_st {
+	char *filename;
+	char *appname;
+	unsigned long flags;
+};
+
+typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 
 # define OPENSSL_INIT_ADD_ALL_CIPHERS        0x00000004L
 # define OPENSSL_INIT_ADD_ALL_DIGESTS        0x00000008L

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -120,11 +120,19 @@ int cryptoCalculateSHA512(unsigned char *hash_buf, const int hash_len, const uns
 int cryptoSetSessionKeysFromPassword(struct s_crypto *session_ctx, const unsigned char *password, const int password_len, const int cipher_algorithm, const int hmac_algorithm);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+# define OPENSSL_INIT_ADD_ALL_CIPHERS        0x00000004L
+# define OPENSSL_INIT_ADD_ALL_DIGESTS        0x00000008L
+# define OPENSSL_INIT_LOAD_CONFIG            0x00000040L
+
 void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key);
 HMAC_CTX *HMAC_CTX_new(void);
 void HMAC_CTX_free(HMAC_CTX *ctx);
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
 #endif
 
 #endif

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -47,9 +47,9 @@
 
 // cipher context storage
 struct s_crypto {
-        EVP_CIPHER_CTX enc_ctx;
-        EVP_CIPHER_CTX dec_ctx;
-        HMAC_CTX hmac_ctx;
+        EVP_CIPHER_CTX *enc_ctx;
+        EVP_CIPHER_CTX *dec_ctx;
+        HMAC_CTX *hmac_ctx;
 };
 
 
@@ -118,5 +118,13 @@ int cryptoCalculateSHA512(unsigned char *hash_buf, const int hash_len, const uns
 
 // generate session keys from password
 int cryptoSetSessionKeysFromPassword(struct s_crypto *session_ctx, const unsigned char *password, const int password_len, const int cipher_algorithm, const int hmac_algorithm);
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key);
+HMAC_CTX *HMAC_CTX_new(void);
+void HMAC_CTX_free(HMAC_CTX *ctx);
+EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
+void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+#endif
 
 #endif

--- a/include/io.h
+++ b/include/io.h
@@ -61,8 +61,8 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
-#include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/epoll.h>
 #endif
 
 #if defined(IO_LINUX)
@@ -89,55 +89,58 @@
 
 // The IO addr structure.
 struct s_io_addr {
-        unsigned char addr[24];
+	unsigned char addr[24];
 };
 
 
 // The IO addrinfo structure.
 struct s_io_addrinfo {
-        struct s_io_addr item[16];
-        int count;
+	struct s_io_addr item[16];
+	int count;
 };
 
 
 // The IO handle structure.
 struct s_io_handle {
-        int enabled;
-        int fd;
-        struct sockaddr_storage source_sockaddr;
-        struct s_io_addr source_addr;
-        int group_id;
-        int content_len;
-        int type;
-        int open;
+	int enabled;
+	int fd;
+	struct sockaddr_storage source_sockaddr;
+	struct s_io_addr source_addr;
+	int group_id;
+	int content_len;
+	int type;
+	int open;
 #if defined(IO_WINDOWS)
-        HANDLE fd_h;
-        int open_h;
-        OVERLAPPED ovlr;
-        int ovlr_used;
-        OVERLAPPED ovlw;
-        int ovlw_used;
+	HANDLE fd_h;
+	int open_h;
+	OVERLAPPED ovlr;
+	int ovlr_used;
+	OVERLAPPED ovlw;
+	int ovlw_used;
 #endif
 };
 
 
 // The IO state structure.
 struct s_io_state {
-        unsigned char *mem;
-        struct s_io_handle *handle;
-        int bufsize;
-        int max;
-        int count;
-        int timeout;
-        int sockmark;
-        int nat64clat;
-        unsigned char nat64_prefix[12];
-        int debug;
+	unsigned char *mem;
+	struct s_io_handle *handle;
+	int bufsize;
+	int max;
+	int count;
+	int timeout;
+	int sockmark;
+	int nat64clat;
+	unsigned char nat64_prefix[12];
+	int debug;
+#if defined(IO_LINUX) || defined(IO_BSD)
+	int epollfd;
+#endif
 };
 
 
 // Returns length of string.
-int ioStrlen(const char *str, const int max_len);
+size_t ioStrlen(const char *str, const size_t max_len);
 
 // Resolve name. Returns number of addresses.
 int ioResolveName(struct s_io_addrinfo *iai, const char *hostname, const char *port);

--- a/src/app/config.c
+++ b/src/app/config.c
@@ -110,68 +110,68 @@ int parseConfigLine(char *line, int len, struct s_initconfig *cs) {
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"local",&vpos)) {
-		strncpy(cs->sourceip,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->sourceip,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"port",&vpos)) {
-		strncpy(cs->sourceport,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->sourceport,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"user",&vpos)) {
-		strncpy(cs->userstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->userstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"group",&vpos)) {
-		strncpy(cs->groupstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->groupstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line, len, "pidfile", &vpos)) {
-		strncpy(cs->pidfile, &line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->pidfile, &line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		cs->enablepidfile = 1;
 		return 1;
 	}
     else if(parseConfigLineCheckCommand(line, len, "privatekey", &vpos)) {
-        strncpy(cs->privatekey, &line[vpos], CONFPARSER_NAMEBUF_SIZE);
+        strncpy(cs->privatekey, &line[vpos], CONFPARSER_NAMEBUF_SIZE+1);
         return 1;
     }
 	else if(parseConfigLineCheckCommand(line,len,"chroot",&vpos)) {
-		strncpy(cs->chrootstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->chrootstr,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"networkname",&vpos)) {
-		strncpy(cs->networkname,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->networkname,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"interface",&vpos)) {
-		strncpy(cs->tapname,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->tapname,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"ifconfig4",&vpos)) {
-		strncpy(cs->ifconfig4,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->ifconfig4,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"ifconfig6",&vpos)) {
-		strncpy(cs->ifconfig6,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->ifconfig6,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"upcmd",&vpos)) {
-		strncpy(cs->upcmd,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->upcmd,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"initpeers",&vpos)) {
-        cs->initpeers[cs->initpeerscount] = malloc(sizeof(char) * CONFPARSER_NAMEBUF_SIZE);
-		strncpy(cs->initpeers[cs->initpeerscount],&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+        cs->initpeers[cs->initpeerscount] = malloc(sizeof(char) * (CONFPARSER_NAMEBUF_SIZE+1));
+		strncpy(cs->initpeers[cs->initpeerscount],&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
         cs->initpeerscount++;
         debug("detected new init peers");
 
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"engine",&vpos)) {
-		strncpy(cs->engines,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->engines,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		return 1;
 	}
 	else if(parseConfigLineCheckCommand(line,len,"psk",&vpos)) {
-		strncpy(cs->password,&line[vpos],CONFPARSER_NAMEBUF_SIZE);
+		strncpy(cs->password,&line[vpos],CONFPARSER_NAMEBUF_SIZE+1);
 		cs->password_len = strlen(cs->password);
 		return 1;
 	}

--- a/src/encryption/crypto.c
+++ b/src/encryption/crypto.c
@@ -400,49 +400,39 @@ void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key) 
 HMAC_CTX *HMAC_CTX_new(void) {
 	HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
 	if (ctx != NULL) {
-		if (!HMAC_CTX_reset(ctx)) {
-			HMAC_CTX_free(ctx);
-			return NULL;
-		}
+		HMAC_CTX_init(ctx);
 	}
 	return ctx;
 }
 
 void HMAC_CTX_free(HMAC_CTX *ctx) {
 	if (ctx != NULL) {
-		hmac_ctx_cleanup(ctx);
-		EVP_MD_CTX_free(ctx->i_ctx);
-		EVP_MD_CTX_free(ctx->o_ctx);
-		EVP_MD_CTX_free(ctx->md_ctx);
+		HMAC_CTX_cleanup(ctx);
 		OPENSSL_free(ctx);
 	}
 }
 
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void) {
 	EVP_CIPHER_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
-	if (ctx != NULL) [
-		if (!EVP_CIPHER_CTX_reset(ctx== {
-			EVP_CIPHER_CTX_free(ctx);
-			return NULL;
-		}
+	if (ctx != NULL) {
+		EVP_CIPHER_CTX_init(ctx);
 	}
 	return ctx;
 }
 
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx) {
 	if (ctx != NULL) {
-		EVP_CIPHER_CTX_reset(ctx);
+		EVP_CIPHER_CTX_cleanup(ctx);
 		OPENSSL_free(ctx);
 	}
 }
 
 EVP_MD_CTX *EVP_MD_CTX_new(void) {
-	return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+	return EVP_MD_CTX_create();
 }
 
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
-	EVP_MD_CTX_cleanup(ctx);
-	OPENSSL_free(ctx);
+	EVP_MD_CTX_destroy(ctx);
 }
 
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings) {

--- a/src/encryption/crypto.c
+++ b/src/encryption/crypto.c
@@ -340,11 +340,11 @@ int cryptoCalculateHash(unsigned char *hash_buf, const int hash_len, const unsig
 	unsigned char hash[EVP_MAX_MD_SIZE];
 	int len;
 	EVP_MD_CTX *ctx;
-	ctx = EVP_MD_CTX_create();
+	ctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(ctx, hash_func, NULL);
 	EVP_DigestUpdate(ctx, in_buf, in_len);
 	EVP_DigestFinal(ctx, hash, (unsigned int *)&len);
-	EVP_MD_CTX_destroy(ctx);
+	EVP_MD_CTX_free(ctx);
 	if(len < hash_len) return 0;
 	memcpy(hash_buf, hash, hash_len);
 	return 1;
@@ -434,6 +434,35 @@ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx) {
 		EVP_CIPHER_CTX_reset(ctx);
 		OPENSSL_free(ctx);
 	}
+}
+
+EVP_MD_CTX *EVP_MD_CTX_new(void) {
+	return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
+	EVP_MD_CTX_cleanup(ctx);
+	OPENSSL_free(ctx);
+}
+
+int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings) {
+	switch (opts) {
+		case OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG:
+			OPENSSL_add_all_algorithms_conf();
+			break;
+		case OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS:
+			OPENSSL_add_all_algorithms_noconf();
+			break;
+		case OPENSSL_INIT_ADD_ALL_CIPHERS:
+			OpenSSL_add_all_ciphers();
+			break;
+		case OPENSSL_INIT_ADD_ALL_DIGESTS:
+			OpenSSL_add_all_digests();
+			break;
+		default:
+			return 0;
+	}
+	return 1;
 }
 #endif
 

--- a/src/encryption/rsa.c
+++ b/src/encryption/rsa.c
@@ -98,7 +98,7 @@ int rsaGetFingerprint(unsigned char *buf, const int buf_size, const struct s_rsa
  * keypath should be accessable
  */
 int rsaImportKey(struct s_rsa * rsa, const char *keypath) {
-    OpenSSL_add_all_algorithms();
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 
     BIO * in;
     RSA * rsakey;
@@ -328,7 +328,7 @@ int rsaCreate(struct s_rsa *rsa) {
     BN_zero(rsa->bn);
     rsa->key = EVP_PKEY_new();
     if(rsa->key != NULL) {
-        rsa->md = EVP_MD_CTX_create();
+        rsa->md = EVP_MD_CTX_new();
         if(rsa->md != NULL) {
             rsaReset(rsa);
             return 1;
@@ -342,7 +342,7 @@ int rsaCreate(struct s_rsa *rsa) {
 // Destroy a RSA object.
 void rsaDestroy(struct s_rsa *rsa) {
 	rsaReset(rsa);
-	EVP_MD_CTX_destroy(rsa->md);
+	EVP_MD_CTX_free(rsa->md);
 	EVP_PKEY_free(rsa->key);
 	BN_free(rsa->bn);
 }

--- a/src/p2p/p2psec.c
+++ b/src/p2p/p2psec.c
@@ -289,7 +289,7 @@ void p2psecDisableRelay(struct s_p2psec *p2psec) {
 int p2psecLoadDefaults(struct s_p2psec *p2psec) {
 	if(!p2psecLoadDH(p2psec)) return 0;
 	p2psecSetFlag(p2psec, (~(0)), 0);
-	p2psecSetMaxConnectedPeers(p2psec, 256);
+	p2psecSetMaxConnectedPeers(p2psec, 65536);
 	p2psecSetAuthSlotCount(p2psec, 32);
 	p2psecDisableLoopback(p2psec);
 	p2psecEnableFastauth(p2psec);

--- a/src/p2p/peeraddr.c
+++ b/src/p2p/peeraddr.c
@@ -27,6 +27,7 @@
 #include "string.h"
 #include <arpa/inet.h>
 #include "p2p.h"
+#include "io.h"
 
 
 // Returns true if PeerAddr is internal.
@@ -89,7 +90,11 @@ void peeraddrSetIndirect(struct s_peeraddr *peeraddr, const int relayid, const i
  */
 void peeraddrToHuman(char * buffer, const struct s_peeraddr * peeraddr) {
     char res[64];
-    inet_ntop(AF_INET, &peeraddr->addr[4], res, 64);
+    if(memcmp(&peeraddr->addr[0], IO_ADDRTYPE_UDP6, 4) == 0) {
+        inet_ntop(AF_INET6, &peeraddr->addr[4], res, 64);
+    } else {
+        inet_ntop(AF_INET, &peeraddr->addr[4], res, 64);
+    }
 
     if(peeraddrGetInternalType(peeraddr) == peeraddr_INTERNAL_INDIRECT) {
         strcpy(buffer, "INDIRECT");


### PR DESCRIPTION
The peer IP address is always interpreted as IPv4 when getting it in human readable format. Now we check if it is IPv6 or IPv4 and use either AF_INET6 or AF_INET to get the correct format.